### PR TITLE
Create new widget types (exchange, iframe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,20 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "luxon": "^2.0.1",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.2",
     "vash": "^0.13.0",
     "yaml": "^1.10.2"
   },
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.7",
+    "@types/luxon": "^1.27.1",
     "@types/node": "^14.0.13",
     "@types/node-fetch": "^2.5.7",
     "@types/yaml": "^1.9.7",

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export type Website = {
 export enum WidgetType {
   Image = "image",
   Text = "text",
+  Iframe = "iframe",
+  BannerExchange = "banner exchange",
 }
 
 export type WidgetCreationRequest = {

--- a/src/widget-cache.ts
+++ b/src/widget-cache.ts
@@ -1,0 +1,33 @@
+import { DateTime } from "luxon";
+import { getRandomWebsite } from "./db";
+import { Website } from "./types";
+
+// Doing the widget cache in memory here for now,
+// we can move it to redis eventually.
+type CacheData = {
+  time: DateTime;
+  targetWebsiteId: string;
+};
+
+let cache: Record<string, CacheData> = {};
+
+export function updateCacheForSite(website: Website) {
+  let cachedSite = cache[website.id];
+  if (!!cachedSite && cachedSite.time.diffNow().as("hours") > 1) {
+    return;
+  }
+
+  const random = getRandomWebsite(website.id);
+  cachedSite = cache[website.id] = {
+    time: DateTime.local(),
+    targetWebsiteId: random.id,
+  };
+}
+
+export function getCachedWidgetData(website: Website) {
+  if (!cache[website.id]) {
+    updateCacheForSite(website);
+  }
+
+  return cache[website.id];
+}

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,11 +1,33 @@
 import { Website, WidgetType } from "./types";
 
+function generateBannerExchasngeWidget(website: Website) {
+  return `
+  <a href="/widget/${website.id}/navigate"><img src="/widget/${website.id}/image" alt="${website.name}" border="0"></a><br>
+  <font size="-1">
+    Proud member of <a href="http://www.theoldnet.com"><b>TheOldNet</b></a> webring! Check some other cool websites!<br>
+    [<a href="/${website.id}/previous/navigate">Previous site</a>] -
+    [<a href="/${website.id}/random/navigate">Random site</a>] -
+    [<a href="/${website.id}/next/navigate">Next site</a>]
+  </font>
+  `;
+}
+
 function generateTextWidget(website: Website) {
   return `
     <b>This site is a proud member of the TheOldNet webring! Check some other cool websites!</b><br>
     <a href="/${website.id}/previous/navigate">Previous site</a> -- 
     <a href="/${website.id}/random/navigate">Random site</a> -- 
     <a href="/${website.id}/next/navigate">Next site</a>
+  `;
+}
+
+function generateIframeWidget(website: Website) {
+  return `
+    <iframe src="/${
+      website.id
+    }/widget" width="470" height="90" frameBorder="0" sandbox="allow-top-navigation allow-scripts allow-forms">
+      ${generateTextWidget(website)}
+    </iframe>
   `;
 }
 
@@ -26,7 +48,11 @@ export function generateWidget(website: Website, widgetType: WidgetType) {
     case WidgetType.Text:
       return generateTextWidget(website);
     case WidgetType.Image:
-    default:
       return generateImageWidget(website);
+    case WidgetType.Iframe:
+      return generateIframeWidget(website);
+    case WidgetType.BannerExchange:
+    default:
+      return generateBannerExchasngeWidget(website);
   }
 }

--- a/views/iframe-widget.vash
+++ b/views/iframe-widget.vash
@@ -1,0 +1,13 @@
+<html>
+<body marginheight="0" topmargin="0" vspace="0" marginwidth="0" leftmargin="0" hspace="0" style="margin:0; padding:0">
+<center>
+  <a href="@model.website.url"><img src="@model.website.banner" alt="@model.website.name" border="0"></a><br>
+  <font size="-1">
+    Proud member of <a href="http://www.theoldnet.com"><b>TheOldNet</b></a> webring! Check some other cool websites!<br>
+    [<a href="/@model.current.id/previous/navigate">Previous site</a>] -
+    [<a href="/@model.current.id/random/navigate">Random site</a>] -
+    [<a href="/@model.current.id/next/navigate">Next site</a>]
+  </font>
+</center>
+</body>
+</html>

--- a/views/widget.vash
+++ b/views/widget.vash
@@ -8,6 +8,8 @@
       <br><br>
       Widget Type:
       <select name="widgetType">
+        <option>Banner Exchange</option>
+        <option>Iframe</option>
         <option>Image</option>
         <option>Text</option>
       </select>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=
+  dependencies:
+    axios "*"
+
 "@types/body-parser@*", "@types/body-parser@^1.19.0":
   version "1.19.1"
   resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
@@ -35,6 +42,11 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/luxon@^1.27.1":
+  version "1.27.1"
+  resolved "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz#aceeb2d5be8fccf541237e184e37ecff5faa9096"
+  integrity sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==
 
 "@types/mime@^1":
   version "1.3.2"
@@ -124,6 +136,13 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+axios@*, axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -352,6 +371,11 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -494,6 +518,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+luxon@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/luxon/-/luxon-2.0.1.tgz#b41ca2f1f5ad8099c18603ae6c36a7794039daf0"
+  integrity sha512-8Eawf81c9ZlQj62W3eq4mp+C7SAIAnmaS7ZuEAiX503YMcn+0C1JnMQRtfaQj6B5qTZLgHv0F4H5WabBCvi1fw==
 
 make-error@^1.1.1:
   version "1.3.6"


### PR DESCRIPTION
I have created two new widget types as an experiment, Banner Exchange that shows the banner of a random website for an hour and Iframe.
I'm not sure about the Iframe one because I can't navigate outside of it without javascript.
Also, it didn't work on Netscape 4.8.

We should probably disable caching for the endpoints related to these widgets so they work properly.